### PR TITLE
update `build.xml` to work with new ant versions

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -117,6 +117,7 @@
     <mkdir dir="war/WEB-INF/classes"/>
     <javac includes="**" encoding="utf-8"
         destdir="war/WEB-INF/classes"
+	includeantruntime="false"
         source="1.7" target="1.7" nowarn="true"
         debug="true" debuglevel="lines,vars,source">
       <src refid="project.java.path"/>


### PR DESCRIPTION
It  warns that` 'includeantruntime' was not set, defaulting to build.sysclasspath=last` when I try to build with ant (v 1.9.3).  I modified `build.xml` to suppress warning caused by the misleading new feature of newer version of `ant`.