### PR TITLE
Add a script to select JDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ Install the dependencies by entering the `dom-distiller` folder and running:
 ```bash
 sudo ./install-build-deps.sh
 ```
-
+If you have multiple JDKs installed, select the right JDK version by running:
+```bash
+source ./select-jdk.sh
+```
 Ubuntu 14.04 64-bit is recommended.
 
 ## Developing on Mac OS X

--- a/select-jdk.sh
+++ b/select-jdk.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Setup Java environment for Ubuntu/Debian with multiple JDKs
+#
+
+if [ "$(id -u)" = "0" ]; then	#already root
+	update-alternatives --config java
+else				#normal users
+	sudo update-alternatives --config java
+fi
+JAVA_LOCATION=`readlink -f /usr/bin/java`
+JAVA_HOME=`echo $JAVA_LOCATION | awk -F '/jre/bin/java' '{print $1}'`
+CLASSPATH=$JAVA_HOME'/lib/dt.jar:'$JAVA_HOME'/lib/tools.jar'
+export JAVA_HOME CLASSPATH
+echo "DONE!\nRun 'source $0' again to change settings back."


### PR DESCRIPTION
The script is helpful when developers have multiple JDKs installed
in the system. It will setup the link to the java binary, as well
as `JAVA_HOME` and `CLASSPATH`. As a newbie in java, I was
confused. Since I figured it out, I hope this could help others.
