### PR TITLE
Fix crashes on iOS.

### DIFF
--- a/java/org/chromium/distiller/DomDistiller.java
+++ b/java/org/chromium/distiller/DomDistiller.java
@@ -47,7 +47,9 @@ public class DomDistiller {
             result.addContentImages().setUrl(url);
         }
 
-        String original_url = options.hasOriginalUrl() ? options.getOriginalUrl() : Window.Location.getHref();
+        // iOS doesn't support reading window.location.href, so we use document.URL instead.
+        String original_url =
+                options.hasOriginalUrl() ? options.getOriginalUrl() : Document.get().getURL();
         TimingInfo timingInfo = contentExtractor.getTimingInfo();
         double stPaging = DomUtil.getTime();
         result.setPaginationInfo(PagingLinksFinder.getPaginationInfo(original_url));

--- a/java/org/chromium/distiller/DomUtil.java
+++ b/java/org/chromium/distiller/DomUtil.java
@@ -112,8 +112,9 @@ public class DomUtil {
     }-*/;
 
     public static native double getTime() /*-{
-        // window.performance is unavailable in Gwt's dev environment.
-        if (window.performance) {
+        // window.performance is unavailable in Gwt's dev environment and even referencing it on iOS
+        // causes a crash.
+        if ((typeof distiller_on_ios === 'undefined' || !distiller_on_ios) && window.performance) {
           return window.performance.now();
         }
         return Date.now();


### PR DESCRIPTION
Merely reading window.location.href or window.performance will crash a UIWebView on iOS.

This PR fixes that by changing window.location.href to document.URL, and allowing the caller to set `distiller_on_ios` to `true` to prevent a reference to `window.performance` in `getTime`, always using `Date.now` on iOS.
